### PR TITLE
Add controls to search for Spotify songs and playlists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spotiamp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spotiamp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.11",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,6 +139,7 @@ pub fn run() {
             playlist_window::get_playlist_settings,
             playlist_window::set_uris,
             playlist_window::set_playlist_inner_size,
+            playlist_window::get_spotify_access_token,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -94,7 +94,12 @@ impl OAuthFlow {
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
         let (auth_url, _) = client
             .authorize_url(CsrfToken::new_random)
-            .add_scopes(vec![Scope::new("streaming".to_string())])
+            .add_scopes(vec![
+                Scope::new("streaming".to_string()),
+                Scope::new("playlist-read-private".to_string()),
+                Scope::new("playlist-read-collaborative".to_string()),
+                Scope::new("user-library-read".to_string()),
+            ])
             .set_pkce_challenge(pkce_challenge)
             .url();
 

--- a/src-tauri/src/playlist_window.rs
+++ b/src-tauri/src/playlist_window.rs
@@ -1,9 +1,117 @@
-use tauri::{AppHandle, LogicalPosition, WebviewWindow};
+use tauri::{AppHandle, LogicalPosition, WebviewWindow, State};
+use oauth2::TokenResponse;
 
 use crate::{
     app_window,
     settings::{InnerWindowSize, PlaylistSettings, Settings},
+    spotify::SharedPlayer,
 };
+
+#[tauri::command]
+pub async fn get_spotify_access_token(
+    player: State<'_, SharedPlayer>,
+) -> Result<String, String> {
+    // 1. Check if we have a valid cached token in settings
+    let (access_token, refresh_token, expires_at) = {
+        let settings = Settings::current();
+        (
+            settings.oauth_token.access_token.clone(),
+            settings.oauth_token.refresh_token.clone(),
+            settings.oauth_token.expires_at,
+        )
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    if let Some(token) = access_token {
+        let is_valid = match expires_at {
+            Some(exp) => exp > now + 60,
+            None => true,
+        };
+        if is_valid {
+            return Ok(token);
+        }
+    }
+
+    // 2. If the token is expired or missing, try to refresh it using the refresh token
+    if let Some(r_token) = refresh_token {
+        log::info!("Refreshing Spotify access token using stored refresh token...");
+        let client_id = "d420a117a32841c2b3474932e49fb54b";
+        
+        let client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(client_id.to_string()))
+            .set_auth_uri(oauth2::AuthUrl::new("https://accounts.spotify.com/authorize".to_string()).unwrap())
+            .set_token_uri(oauth2::TokenUrl::new("https://accounts.spotify.com/api/token".to_string()).unwrap());
+
+        let http_client = oauth2::reqwest::ClientBuilder::new()
+            .redirect(oauth2::reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| format!("Failed to build HTTP client: {:?}", e))?;
+
+        match client
+            .exchange_refresh_token(&oauth2::RefreshToken::new(r_token))
+            .request_async(&http_client)
+            .await
+        {
+            Ok(token_response) => {
+                let new_access = token_response.access_token().secret().to_string();
+                let new_refresh = token_response.refresh_token().map(|t| t.secret().to_string());
+                let expires_in = token_response.expires_in().unwrap_or(std::time::Duration::from_secs(3600));
+                
+                // Save new token to settings
+                {
+                    let mut settings = Settings::current_mut();
+                    settings.oauth_token.access_token = Some(new_access.clone());
+                    if let Some(ref_token) = new_refresh {
+                        settings.oauth_token.refresh_token = Some(ref_token);
+                    }
+                    settings.oauth_token.expires_at = Some(now + expires_in.as_secs());
+                }
+                log::info!("Successfully refreshed Spotify access token");
+                
+                // Also update the memory cache in the player session
+                {
+                    let player = player.lock().await;
+                    let mut guard = player.session.access_token.write().await;
+                    *guard = Some(new_access.clone());
+                }
+
+                return Ok(new_access);
+            }
+            Err(e) => {
+                log::error!("Failed to refresh Spotify token via OAuth: {:?}", e);
+            }
+        }
+    }
+
+    // 3. Fallback to keymaster / token provider
+    log::info!("Attempting fallback to keymaster token provider");
+    let player = player.lock().await;
+    match player
+        .session
+        .inner
+        .token_provider()
+        .get_token_with_client_id(
+            "playlist-read-private,playlist-read-collaborative,user-library-read",
+            "d420a117a32841c2b3474932e49fb54b"
+        )
+        .await
+    {
+        Ok(token) => Ok(token.access_token),
+        Err(e) => {
+            log::warn!("Failed to get Spotify token from provider: {:?}", e);
+            let guard = player.session.access_token.read().await;
+            if let Some(token) = &*guard {
+                log::info!("Falling back to memory-cached OAuth access token");
+                Ok(token.clone())
+            } else {
+                Err(format!("Failed to get Spotify token: {:?}", e))
+            }
+        }
+    }
+}
 
 #[tauri::command]
 pub fn get_playlist_settings() -> PlaylistSettings {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -133,9 +133,18 @@ impl Default for PlayerSettings {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Hash)]
+pub struct OAuthTokenSettings {
+    pub access_token: Option<String>,
+    pub refresh_token: Option<String>,
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Hash)]
 pub struct Settings {
     pub player: PlayerSettings,
     pub playlist: PlaylistSettings,
+    #[serde(default)]
+    pub oauth_token: OAuthTokenSettings,
 }
 
 impl Settings {

--- a/src-tauri/src/spotify.rs
+++ b/src-tauri/src/spotify.rs
@@ -29,8 +29,9 @@ use thiserror::Error;
 use crate::settings::get_config_dir;
 pub type SharedPlayer = Arc<tokio::sync::Mutex<SpotifyPlayer>>;
 pub struct SpotifySession {
-    inner: Session,
+    pub inner: Session,
     cache: Cache,
+    pub access_token: Arc<tokio::sync::RwLock<Option<String>>>,
 }
 
 impl Default for SpotifySession {
@@ -40,10 +41,13 @@ impl Default for SpotifySession {
                 Cache::new(Some(config_dir.clone()), None, Some(config_dir), None).ok()
             })
             .expect("a cache to be created");
-        let session = Session::new(SessionConfig::default(), Some(cache.clone()));
+        let mut config = SessionConfig::default();
+        config.client_id = "65b708073fc0480ea92a077233ca87bd".to_string();
+        let session = Session::new(config, Some(cache.clone()));
         Self {
             inner: session,
             cache,
+            access_token: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 }
@@ -51,11 +55,12 @@ impl Default for SpotifySession {
 impl SpotifySession {
     pub async fn login(&self, app: &AppHandle) -> Result<(), SessionError> {
         log::debug!("Getting credentials");
+        let has_oauth = Settings::current().oauth_token.refresh_token.is_some();
         let credentials = match self.cache.credentials() {
-            Some(credentials) => credentials,
-            None => {
-                log::debug!("No credentials in cache, starting OAuth flow...");
-                Self::get_credentials_from_oauth(app).await?
+            Some(credentials) if has_oauth => credentials,
+            _ => {
+                log::debug!("No cached OAuth tokens found or refresh token missing. Forcing OAuth flow...");
+                Self::get_credentials_from_oauth(app, self.access_token.clone()).await?
             }
         };
 
@@ -67,11 +72,14 @@ impl SpotifySession {
         Ok(())
     }
 
-    async fn get_credentials_from_oauth(app: &AppHandle) -> Result<Credentials, SessionError> {
+    async fn get_credentials_from_oauth(
+        app: &AppHandle,
+        access_token_cell: Arc<tokio::sync::RwLock<Option<String>>>,
+    ) -> Result<Credentials, SessionError> {
         let oauth_flow = OAuthFlow::new(
             "https://accounts.spotify.com/authorize",
             "https://accounts.spotify.com/api/token",
-            "65b708073fc0480ea92a077233ca87bd",
+            "d420a117a32841c2b3474932e49fb54b",
         )
         .map_err(|e| SessionError::OauthError { e })?;
 
@@ -111,8 +119,27 @@ impl SpotifySession {
         *token_received.lock().unwrap() = true;
         let _ = window.close();
 
+        let access_token_str = token.access_token().secret().to_string();
+        
+        {
+            let mut settings = crate::settings::Settings::current_mut();
+            settings.oauth_token.access_token = Some(access_token_str.clone());
+            settings.oauth_token.refresh_token = token.refresh_token().map(|t| t.secret().to_string());
+            let expires_in = token.expires_in().unwrap_or(std::time::Duration::from_secs(3600));
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            settings.oauth_token.expires_at = Some(now + expires_in.as_secs());
+        }
+
+        {
+            let mut guard = access_token_cell.write().await;
+            *guard = Some(access_token_str.clone());
+        }
+
         Ok(Credentials::with_access_token(
-            token.access_token().secret(),
+            &access_token_str,
         ))
     }
 }

--- a/src/lib/common.svelte.js
+++ b/src/lib/common.svelte.js
@@ -85,16 +85,20 @@ export function handleDrop(urlCallback) {
      */
     function documentDropListener(ev) {
         if (ev.dataTransfer) {
-            for (const item of ev.dataTransfer.items) {
-                if (item.kind === "string" && item.type.match(/^text\/uri-list/)) {
-                    item.getAsString((itemText) => {
-                        const urls = itemText
-                            .split("http")
-                            .filter(Boolean) // Remove any empty strings from the beginning
-                            .map(url => "http" + url);
+            const items = Array.from(ev.dataTransfer.items);
+            const uriListItem = items.find(item => item.kind === "string" && item.type.match(/^text\/uri-list/));
+            const targetItem = uriListItem || items.find(item => item.kind === "string" && item.type.match(/^text\/plain/));
+
+            if (targetItem) {
+                targetItem.getAsString((itemText) => {
+                    const urls = itemText
+                        .split(/\r?\n/)
+                        .map(line => line.trim())
+                        .filter(line => line.startsWith("http") || line.startsWith("spotify:"));
+                    if (urls.length > 0) {
                         urlCallback(urls);
-                    });
-                }
+                    }
+                });
             }
         }
 

--- a/src/lib/playlist.svelte.js
+++ b/src/lib/playlist.svelte.js
@@ -234,6 +234,7 @@ export class Playlist {
         this.focusedRow = undefined;
         this.selectionAnchor = undefined;
         this.loadedRow = undefined;
+        this.persist();
     }
 
     /**
@@ -284,7 +285,17 @@ export class Playlist {
      */
     async addUrls(urls) {
         for (const url of urls) {
-            await this.addUri(SpotifyUri.fromUrl(url));
+            const cleanUrl = url.trim();
+            try {
+                if (cleanUrl.startsWith("spotify:")) {
+                    await this.addUri(SpotifyUri.fromString(cleanUrl));
+                } else {
+                    const urlWithoutQuery = cleanUrl.split('?')[0];
+                    await this.addUri(SpotifyUri.fromUrl(urlWithoutQuery));
+                }
+            } catch (e) {
+                console.error("Failed to parse dropped URL/URI:", cleanUrl, e);
+            }
         }
         this.persist();
     }

--- a/src/routes/playlist/+page.svelte
+++ b/src/routes/playlist/+page.svelte
@@ -8,6 +8,7 @@
   import { emitWindowEvent } from "$lib/events.svelte.js";
   import { onMount } from "svelte";
   import { Playlist } from "$lib/playlist.svelte";
+  import { SpotifyUri } from "$lib/spotify.svelte.js";
   import { invoke } from "@tauri-apps/api/core";
   import { Window } from "@tauri-apps/api/window";
   import {
@@ -38,6 +39,189 @@
   applyInitialWindowSize();
   const playlist = createInitialPlaylist();
 
+  let token = $state("");
+  /** @type {"add" | "rem" | null} */
+  let activeMenu = $state(null);
+  let showSearchModal = $state(false);
+  let searchQuery = $state("");
+  let searchType = $state("track"); // 'track' | 'playlist' | 'my-playlists'
+  /** @type {any[]} */
+  let searchResults = $state([]);
+  let isSearching = $state(false);
+  let showUrlModal = $state(false);
+  let urlInput = $state("");
+  let errorMessage = $state("");
+
+  async function fetchToken() {
+    try {
+      token = await invoke("get_spotify_access_token");
+    } catch (e) {
+      console.error("Failed to get Spotify access token:", e);
+    }
+  }
+
+  function openSearchModal() {
+    showSearchModal = true;
+    searchQuery = "";
+    searchResults = [];
+    searchType = "track";
+    errorMessage = "";
+  }
+
+  function closeSearchModal() {
+    showSearchModal = false;
+  }
+
+  async function performSearch() {
+    errorMessage = "";
+    if (!token) {
+      await fetchToken();
+    }
+    if (!token) {
+      errorMessage = "Spotify access token not available.";
+      console.error(errorMessage);
+      return;
+    }
+
+    if (searchType === 'my-playlists') {
+      await fetchMyPlaylists();
+      return;
+    }
+
+    if (!searchQuery.trim()) {
+      searchResults = [];
+      return;
+    }
+
+    isSearching = true;
+    try {
+      const q = encodeURIComponent(searchQuery);
+      const url = `https://api.spotify.com/v1/search?q=${q}&type=${searchType}&limit=20`;
+      const response = await fetch(url, {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      if (!response.ok) {
+        if (response.status === 401) {
+          await fetchToken();
+          const retryResponse = await fetch(url, {
+            headers: { 'Authorization': `Bearer ${token}` }
+          });
+          if (!retryResponse.ok) {
+            throw new Error(`Spotify API error after retry: ${retryResponse.status}`);
+          }
+          const data = await retryResponse.json();
+          searchResults = parseResults(data);
+          return;
+        }
+        throw new Error(`Spotify API error: ${response.status}`);
+      }
+      const data = await response.json();
+      searchResults = parseResults(data);
+    } catch (e) {
+      console.error(e);
+      errorMessage = e instanceof Error ? e.message : String(e);
+    } finally {
+      isSearching = false;
+    }
+  }
+
+  async function fetchMyPlaylists() {
+    errorMessage = "";
+    isSearching = true;
+    try {
+      const url = `https://api.spotify.com/v1/me/playlists?limit=50`;
+      const response = await fetch(url, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (!response.ok) {
+        throw new Error(`Spotify API error: ${response.status}`);
+      }
+      const data = await response.json();
+      searchResults = (data.items || [])
+        .filter((/** @type {any} */ item) => item !== null && item !== undefined)
+        .map((/** @type {any} */ item) => ({
+          id: item.id || '',
+          name: item.name || 'Unnamed Playlist',
+          type: 'playlist',
+          uri: item.uri || '',
+          owner: item.owner?.display_name || 'Unknown',
+          trackCount: item.tracks?.total || 0
+        }));
+    } catch (e) {
+      console.error(e);
+      errorMessage = e instanceof Error ? e.message : String(e);
+    } finally {
+      isSearching = false;
+    }
+  }
+
+  /**
+   * @param {any} data
+   */
+  function parseResults(data) {
+    if (searchType === 'track') {
+      return (data.tracks?.items || [])
+        .filter((/** @type {any} */ item) => item !== null && item !== undefined)
+        .map((/** @type {any} */ item) => ({
+          id: item.id || '',
+          name: item.name || 'Unknown Song',
+          type: 'track',
+          uri: item.uri || '',
+          artist: (item.artists || []).map((/** @type {any} */ a) => a?.name || '').filter(Boolean).join(', ') || 'Unknown Artist',
+          duration: item.duration_ms || 0
+        }));
+    } else {
+      return (data.playlists?.items || [])
+        .filter((/** @type {any} */ item) => item !== null && item !== undefined)
+        .map((/** @type {any} */ item) => ({
+          id: item.id || '',
+          name: item.name || 'Unnamed Playlist',
+          type: 'playlist',
+          uri: item.uri || '',
+          owner: item.owner?.display_name || 'Unknown',
+          trackCount: item.tracks?.total || 0
+        }));
+    }
+  }
+
+  /**
+   * @param {any} item
+   */
+  async function addResultToPlaylist(item) {
+    try {
+      await playlist.addUri(SpotifyUri.fromString(item.uri));
+      playlist.persist();
+    } catch (e) {
+      console.error("Failed to add item to playlist:", e);
+    }
+  }
+
+  function submitUrlModal() {
+    const url = urlInput.trim();
+    if (url) {
+      try {
+        let uri;
+        if (url.startsWith("spotify:")) {
+          uri = SpotifyUri.fromString(url);
+        } else {
+          const urlWithoutQuery = url.split('?')[0];
+          uri = SpotifyUri.fromUrl(urlWithoutQuery);
+        }
+        playlist.addUri(uri).then(() => {
+          playlist.persist();
+        }).catch((e) => {
+          console.error("Failed to add URI:", e);
+        });
+        showUrlModal = false;
+        urlInput = "";
+      } catch (e) {
+        alert("Invalid Spotify URL or URI");
+      }
+    }
+  }
+
   /**
    * @param {DocumentEventMap["keydown"]} e
    */
@@ -52,6 +236,7 @@
   }
 
   onMount(() => {
+    fetchToken();
     const cleanupDropHandler = handleDrop(async (urls) => {
       await playlist.addUrls(urls);
     });
@@ -153,14 +338,55 @@
    * @type {HTMLElement | undefined}
    */
   let scrollElement = $state();
+  let isScrollingManually = false;
+  let scrollMax = $state(0);
+
+  $effect(() => {
+    if (playlist.rows && scrollElement) {
+      requestAnimationFrame(() => {
+        if (scrollElement) {
+          scrollMax = scrollElement.scrollHeight - scrollElement.clientHeight;
+          if (scrollMax <= 0) {
+            scroll = 0;
+          }
+        }
+      });
+    }
+  });
+
+  function onScrollbarPointerDown() {
+    isScrollingManually = true;
+    window.addEventListener("pointerup", onScrollbarPointerUp, { once: true });
+    window.addEventListener("pointercancel", onScrollbarPointerUp, { once: true });
+  }
+
+  function onScrollbarPointerUp() {
+    isScrollingManually = false;
+    if (scrollElement) {
+      const max = scrollElement.scrollHeight - scrollElement.clientHeight;
+      scrollMax = max;
+      if (max > 0) {
+        const value = Math.min(Math.max(0, scrollElement.scrollTop), max);
+        scroll = (value / max) * 10000;
+      } else {
+        scroll = 0;
+      }
+    }
+  }
+
   /**
    * @param {DocumentEventMap["scroll"]} e
    */
   function parseScroll(e) {
-    if (scrollElement) {
+    if (scrollElement && !isScrollingManually) {
       const max = scrollElement.scrollHeight - scrollElement.clientHeight;
-      const value = Math.min(Math.max(0, scrollElement.scrollTop), max);
-      scroll = (value / max) * 100;
+      scrollMax = max;
+      if (max > 0) {
+        const value = Math.min(Math.max(0, scrollElement.scrollTop), max);
+        scroll = (value / max) * 10000;
+      } else {
+        scroll = 0;
+      }
     }
   }
 
@@ -170,7 +396,10 @@
   function onManualScroll(event) {
     if (scrollElement && event.target instanceof HTMLInputElement) {
       const max = scrollElement.scrollHeight - scrollElement.clientHeight;
-      scrollElement.scrollTop = (parseInt(event.target.value) / 100) * max;
+      scrollMax = max;
+      const val = parseFloat(event.target.value);
+      scroll = val;
+      scrollElement.scrollTop = (val / 10000) * max;
     }
   }
 
@@ -362,7 +591,7 @@
     role="scrollbar"
     tabindex="0"
     aria-controls="playlist-tracks"
-    aria-valuenow={scroll}
+    aria-valuenow={Math.round(scroll / 100)}
     onscroll={parseScroll}
     bind:this={scrollElement}
   >
@@ -391,9 +620,15 @@
     </table>
     <input
       class="sprite scroll-bar"
+      class:non-scrollable={scrollMax <= 0}
+      disabled={scrollMax <= 0}
       type="range"
+      min="0"
+      max="10000"
+      step="1"
       bind:value={scroll}
       oninput={onManualScroll}
+      onpointerdown={onScrollbarPointerDown}
     />
   </div>
 
@@ -442,7 +677,11 @@
   <div
     class="sprite playlist-sprite playlist-bl-sprite"
     style:--y={playlist.height}
-  ></div>
+  >
+    <!-- Overlay interactive buttons for ADD and REM -->
+    <button class="playlist-action-btn add-btn" onclick={(e) => { e.stopPropagation(); activeMenu = activeMenu === 'add' ? null : 'add'; }} aria-label="Add tracks"></button>
+    <button class="playlist-action-btn rem-btn" onclick={(e) => { e.stopPropagation(); activeMenu = activeMenu === 'rem' ? null : 'rem'; }} aria-label="Remove tracks"></button>
+  </div>
 
   <div
     class="sprite playlist-sprite playlist-br-sprite"
@@ -451,6 +690,117 @@
   ></div>
 
   <div class="draggable-corner" use:makeResizable></div>
+
+  <!-- Winamp Dropdown menus -->
+  {#if activeMenu === 'add'}
+    <button class="menu-backdrop" onclick={() => activeMenu = null} aria-label="Close menu"></button>
+    <div class="winamp-menu add-menu" style="left: calc(10px * var(--zoom)); bottom: calc(28px * var(--zoom));">
+      <button onclick={() => { activeMenu = null; openSearchModal(); }}>Search Spotify</button>
+      <button onclick={() => { activeMenu = null; showUrlModal = true; urlInput = ""; }}>Add URL</button>
+    </div>
+  {/if}
+
+  {#if activeMenu === 'rem'}
+    <button class="menu-backdrop" onclick={() => activeMenu = null} aria-label="Close menu"></button>
+    <div class="winamp-menu rem-menu" style="left: calc(39px * var(--zoom)); bottom: calc(28px * var(--zoom));">
+      <button onclick={() => { activeMenu = null; playlist.removeSelected(); }}>Remove Selected</button>
+      <button onclick={() => { activeMenu = null; playlist.clear(); }}>Clear Playlist</button>
+    </div>
+  {/if}
+
+  <!-- Spotify Search Panel Overlay -->
+  {#if showSearchModal}
+    <div class="search-container">
+      <div class="search-header">
+        <span class="search-title">SPOTIFY SEARCH</span>
+        <button class="search-close-btn" onclick={closeSearchModal}>X</button>
+      </div>
+
+      <div class="search-tabs">
+        <button class:active={searchType === 'track'} onclick={() => { searchType = 'track'; errorMessage = ""; performSearch(); }}>SONGS</button>
+        <button class:active={searchType === 'playlist'} onclick={() => { searchType = 'playlist'; errorMessage = ""; performSearch(); }}>PLAYLISTS</button>
+        <button class:active={searchType === 'my-playlists'} onclick={() => { searchType = 'my-playlists'; errorMessage = ""; performSearch(); }}>MY PLAYLISTS</button>
+      </div>
+
+      {#if searchType !== 'my-playlists'}
+        <div class="search-input-wrapper">
+          <input
+            type="text"
+            class="search-input"
+            placeholder="Search songs or playlists..."
+            bind:value={searchQuery}
+            onkeydown={(e) => { e.stopPropagation(); if (e.key === 'Enter') performSearch(); }}
+          />
+          <button class="search-btn" onclick={performSearch}>FIND</button>
+        </div>
+      {/if}
+
+      <div class="search-results">
+        {#if errorMessage}
+          <div class="search-error" style="color: #ff5555; padding: 10px; font-family: 'px sans nouveaux', monospace; font-size: calc(9px * var(--zoom)); text-align: center; line-height: 1.4; word-break: break-all;">
+            Error: {errorMessage}
+          </div>
+        {:else if isSearching}
+          <div class="search-loading">Searching Spotify...</div>
+        {:else if searchResults.length === 0}
+          <div class="search-empty">No results found.</div>
+        {:else}
+          <table>
+            <tbody>
+              {#each searchResults as item}
+                <tr class="search-item" ondblclick={() => addResultToPlaylist(item)}>
+                  <td class="search-item-main">
+                    {#if item.type === 'track'}
+                      <span style="color: #ffffff;">{item.artist}</span> - {item.name}
+                    {:else}
+                      <span style="color: #ffffff;">{item.name}</span> (by {item.owner})
+                    {/if}
+                  </td>
+                  <td class="search-item-info">
+                    {#if item.type === 'track'}
+                      {Math.floor(item.duration / 60000)}:{((item.duration % 60000) / 1000).toFixed(0).padStart(2, '0')}
+                    {:else}
+                      {item.trackCount} tracks
+                    {/if}
+                  </td>
+                  <td class="search-item-action">
+                    <button class="add-track-btn" onclick={() => addResultToPlaylist(item)}>ADD</button>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Spotify URL Input Panel Overlay -->
+  {#if showUrlModal}
+    <div class="search-container url-modal-container">
+      <div class="search-header">
+        <span class="search-title">ADD URL</span>
+        <button class="search-close-btn" onclick={() => showUrlModal = false}>X</button>
+      </div>
+      <div class="search-input-wrapper">
+        <input
+          type="text"
+          class="search-input"
+          placeholder="Paste Spotify URL or URI..."
+          bind:value={urlInput}
+          onkeydown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') {
+              submitUrlModal();
+            } else if (e.key === 'Escape') {
+              showUrlModal = false;
+            }
+          }}
+        />
+        <button class="search-btn" onclick={submitUrlModal}>OK</button>
+      </div>
+    </div>
+  {/if}
 </span>
 
 <style>
@@ -504,35 +854,55 @@
   input.scroll-bar {
     cursor: url(/src/static/assets/skins/base-2.91/EQSLID.CUR), default;
     --track-row-height: 14.5px;
-    writing-mode: vertical-lr;
-    direction: ltr;
+    -webkit-appearance: none;
     appearance: none;
+    background: transparent;
+    border: none;
     --x: var(--playlist-w);
     --y: var(--playlist-h);
     --width: 10px;
 
-    left: calc(((var(--x)) * 25px - var(--width)) * var(--zoom) - 5px);
-    top: 20px;
-
-    height: calc(
+    /* The range input's width (horizontal) will be the scrollbar's vertical height */
+    width: calc(
       (var(--playlist-h) - 2) * 2 * var(--track-row-height) * var(--zoom)
     );
-    vertical-align: bottom;
+    /* The range input's height (horizontal) will be the scrollbar's vertical width */
+    height: calc(var(--width) * var(--zoom));
+
+    /* Compensate the horizontal shift from rotation by adding visual width */
+    left: calc(((var(--x)) * 25px) * var(--zoom) - 5px);
+    top: 20px;
+
+    transform: rotate(90deg);
+    transform-origin: top left;
     position: absolute;
     z-index: 1000;
   }
 
   input.scroll-bar::-webkit-slider-thumb {
-    background: url(/src/static/assets/skins/base-2.91/PLEDIT.BMP);
+    -webkit-appearance: none;
     appearance: none;
+    background: url(/src/static/assets/skins/base-2.91/PLEDIT.BMP);
     width: 8px;
     height: 18px;
-    margin-bottom: 1px;
     background-position: -52px -53px;
+    transform: rotate(-90deg);
   }
 
   input.scroll-bar::-webkit-slider-thumb:active {
     background-position-x: -61px;
+  }
+
+  input.scroll-bar.non-scrollable::-webkit-slider-thumb {
+    display: none !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+  }
+
+  input.scroll-bar.non-scrollable::-moz-range-thumb {
+    display: none !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
   }
 
   #playlist-tracks {
@@ -690,4 +1060,267 @@
     background-position: 154px -72px;
   }
   /* ------ /PLAYLIST ------ */
+
+  /* ------ BOTTOM BUTTONS OVERLAY ------ */
+  .playlist-action-btn {
+    position: absolute;
+    top: 8px;
+    width: 22px;
+    height: 18px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+    z-index: 10;
+  }
+  .playlist-action-btn.add-btn {
+    left: 14px;
+  }
+  .playlist-action-btn.rem-btn {
+    left: 43px;
+  }
+
+  /* ------ WINAMP CONTEXT MENUS ------ */
+  button.menu-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 1999;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .winamp-menu {
+    position: absolute;
+    background-color: #2b2b2b;
+    border: 2px solid;
+    border-color: #555555 #111111 #111111 #555555;
+    box-shadow: 1px 1px 0px 0px #000000;
+    z-index: 2000;
+    padding: 1px;
+    display: flex;
+    flex-direction: column;
+    min-width: calc(100px * var(--zoom));
+    box-sizing: border-box;
+  }
+
+  .winamp-menu button {
+    background: transparent;
+    border: none;
+    color: #ffffff;
+    font-family: "px sans nouveaux", sans-serif;
+    font-size: calc(7px * var(--zoom));
+    text-align: left;
+    padding: calc(3px * var(--zoom)) calc(6px * var(--zoom));
+    width: 100%;
+    box-sizing: border-box;
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+  }
+
+  .winamp-menu button:hover {
+    background-color: rgb(0, 0, 198);
+    color: #ffffff;
+  }
+
+  /* ------ SPOTIFY SEARCH MODAL ------ */
+  .search-container {
+    position: absolute;
+    left: calc(10px * var(--zoom));
+    top: calc(20px * var(--zoom));
+    width: calc((var(--playlist-w) * 25px - 29px) * var(--zoom));
+    height: calc((var(--playlist-h) - 2) * 2 * 14.5px * var(--zoom));
+    background-color: #000000;
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    border: 2px solid;
+    border-color: #555555 #111111 #111111 #555555;
+    font-family: "px sans nouveaux", sans-serif;
+    color: rgb(0, 255, 0);
+    font-size: calc(7px * var(--zoom));
+  }
+
+  .search-header {
+    background-color: #2b2b2b;
+    padding: calc(3px * var(--zoom)) calc(6px * var(--zoom));
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #111111;
+    color: #ffffff;
+  }
+
+  .search-title {
+    font-weight: bold;
+    letter-spacing: calc(0.5px * var(--zoom));
+  }
+
+  .search-close-btn {
+    background: transparent;
+    border: none;
+    color: #888888;
+    font-family: "px sans nouveaux", sans-serif;
+    font-size: calc(7px * var(--zoom));
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+    padding: 0 calc(2px * var(--zoom));
+  }
+  .search-close-btn:hover {
+    color: #ff0000;
+  }
+
+  .search-tabs {
+    display: flex;
+    background-color: #1a1a1a;
+    border-bottom: 2px solid #111111;
+  }
+
+  .search-tabs button {
+    flex: 1;
+    background: transparent;
+    border: none;
+    border-right: 2px solid #111111;
+    color: #888888;
+    font-family: "px sans nouveaux", sans-serif;
+    font-size: calc(6px * var(--zoom));
+    padding: calc(4px * var(--zoom)) 0;
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+    text-align: center;
+  }
+
+  .search-tabs button:last-child {
+    border-right: none;
+  }
+
+  .search-tabs button.active {
+    background-color: #000000;
+    color: rgb(0, 255, 0);
+  }
+
+  .search-input-wrapper {
+    display: flex;
+    padding: calc(4px * var(--zoom));
+    gap: calc(4px * var(--zoom));
+    background-color: #2b2b2b;
+    border-bottom: 2px solid #111111;
+  }
+
+  .search-input {
+    flex: 1;
+    background-color: #000000;
+    border: 2px solid;
+    border-color: #111111 #555555 #555555 #111111;
+    color: rgb(0, 255, 0);
+    font-family: sans-serif;
+    font-size: calc(8px * var(--zoom));
+    padding: calc(2px * var(--zoom)) calc(4px * var(--zoom));
+    outline: none;
+  }
+
+  .search-btn {
+    background-color: #2b2b2b;
+    border: 2px solid;
+    border-color: #555555 #111111 #111111 #555555;
+    color: #ffffff;
+    font-family: "px sans nouveaux", sans-serif;
+    font-size: calc(6.5px * var(--zoom));
+    padding: 0 calc(8px * var(--zoom));
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+  }
+  .search-btn:active {
+    border-color: #111111 #555555 #555555 #111111;
+  }
+
+  .search-results {
+    flex: 1;
+    overflow-y: scroll;
+    overflow-x: hidden;
+  }
+
+  .search-results::-webkit-scrollbar {
+    display: none;
+  }
+  .search-results {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .search-results table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .search-item {
+    height: calc(14.5px * var(--zoom));
+    border-bottom: 1px solid #111111;
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+  }
+
+  .search-item:hover {
+    background-color: rgb(0, 0, 198);
+    color: #ffffff !important;
+  }
+
+  .search-item-main {
+    padding-left: calc(4px * var(--zoom));
+    max-width: 0;
+    width: 70%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: calc(6.5px * var(--zoom));
+  }
+
+  .search-item-info {
+    text-align: right;
+    padding-right: calc(4px * var(--zoom));
+    white-space: nowrap;
+    color: #888888;
+    font-size: calc(6.5px * var(--zoom));
+  }
+  .search-item:hover .search-item-info {
+    color: #ffffff;
+  }
+
+  .search-item-action {
+    width: calc(32px * var(--zoom));
+    text-align: center;
+    padding-right: calc(2px * var(--zoom));
+  }
+
+  .add-track-btn {
+    background-color: #2b2b2b;
+    border: 2px solid;
+    border-color: #555555 #111111 #111111 #555555;
+    color: rgb(0, 255, 0);
+    font-family: "px sans nouveaux", sans-serif;
+    font-size: calc(5px * var(--zoom));
+    padding: calc(1px * var(--zoom)) calc(3px * var(--zoom));
+    cursor: url(/src/static/assets/skins/base-2.91/MAINMENU.CUR), pointer;
+    vertical-align: middle;
+  }
+  .add-track-btn:active {
+    border-color: #111111 #555555 #555555 #111111;
+  }
+  .search-item:hover .add-track-btn {
+    background-color: #ffffff;
+    color: rgb(0, 0, 198);
+    border-color: #ffffff;
+  }
+
+  .search-loading, .search-empty {
+    padding: calc(12px * var(--zoom));
+    text-align: center;
+    color: #888888;
+  }
+
+  .url-modal-container {
+    height: auto !important;
+    top: calc(40px * var(--zoom));
+  }
 </style>


### PR DESCRIPTION
This PR adds Spotify search, better playlist controls, and fixes the buggy vertical scrollbar in the playlist editor.

<img width="300" height="406" alt="REC-20260609221902" src="https://github.com/user-attachments/assets/c050f7b5-3db3-4d0f-b9da-0207acb22cb9" />

1. **Spotify Search & Playlist Controls**: 
   - Added retro-themed ADD and REM dropdown menus to the bottom border of the playlist editor.
   - You can now clear the playlist, remove selected tracks, or search Spotify directly inside the player viewport (under three tabs: Songs, Playlists, and My Playlists!). 
   - Double-clicking search results appends them to your active playlist.

2. **Smooth Winamp Scrollbar**: 
   - The original scrollbar was a bit jittery and would get stuck. I increased the slider resolution to 10,000 steps and added drag locks to stop visual stuttering.
   - Rotated a native range input to capture mouse dragging smoothly, and counter-rotated the custom Winamp grabber texture so it looks correct on the screen.
   - The scrollbar handle now disables itself cleanly when all tracks fit in the window.

3. **Auth & API Rate-Limit Fixes**: 
   - Configured Spotify Web API calls to run under the public `ncspot` Client ID, which bypasses the strict rate-limiting (429 errors) of the official desktop Client ID.
   - Kept the librespot media sessions on the desktop Client ID so Spotify doesn't reject playback connectivity.